### PR TITLE
bug fix for maximum numeric value being plotted

### DIFF
--- a/R/prep_objects.R
+++ b/R/prep_objects.R
@@ -204,10 +204,10 @@ prep.numeric<-function(
 		rownames(circle.points)<-circle.points$label
 
 	# line info prep
-	line.list<-as.data.frame(cbind(t(combn(point.names, 2)), as.vector(dataset$dist)), 
-		stringsAsFactors=FALSE)
+	line.list <- data.frame(t(combn(point.names, 2)),
+			as.vector(dataset$dist),
+                        stringsAsFactors = FALSE)
 	colnames(line.list)<-c("sp1", "sp2", "value")
-	line.list$value<-as.numeric(line.list$value)
 
 	# order line list by effect size
 	effect.size<-line.list$value^2


### PR DESCRIPTION
Hi Martin,

I noticed a bug in which the maximum value in a numeric matrix was not being plotted.
This was because of the line (fixed here) in `prep.numeric` which coerced the numeric values to character and back again; this caused a rounding error and meant the highest value was above the highest value in `plot.control$line.breaks`, so the assigned colour was NA and no line plotted for the strongest link.

There's an MRE of the bug in this gist: https://gist.github.com/goldingn/bcbf066717fb0618ae3c
you can switch between the two versions at the top of the gist.

Thanks for all your work on this package, it produces some really nice results!

Cheers,
Nick
